### PR TITLE
initial attempt at a setup.py for easy pip installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='estool',
+      version='1.0',
+      description='Implementation of various Evolution Strategies',
+      author='David Ha',
+      author_email='hardmaru@gmail.com',
+      url='https://github.com/hardmaru/estool',
+      py_modules=['config', 'es', 'env', 'model', 'train'],
+     )


### PR DESCRIPTION
This permits installation via `pip install git+https://github.com/slremy/estool`

Then the normal:

```
Python 3.6.5 (default, Apr 10 2018, 17:08:37) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-16)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from es import SimpleGA
```
