### PR TITLE
fix reward_list (average instead of total of all run)

### DIFF
--- a/train.py
+++ b/train.py
@@ -268,7 +268,7 @@ def evaluate_batch(model_params, max_len=-1):
   send_packets_to_slaves(packet_list)
   reward_list_total = receive_packets_from_slaves()
 
-  reward_list = reward_list_total[:, 0] # get rewards
+  reward_list = reward_list_total[:,0]/(reward_list_total[:,1]+1) # get rewards
   return np.mean(reward_list)
 
 def master():
@@ -314,7 +314,7 @@ def master():
     send_packets_to_slaves(packet_list)
     reward_list_total = receive_packets_from_slaves()
 
-    reward_list = reward_list_total[:, 0] # get rewards
+    reward_list = reward_list_total[:,0]/(reward_list_total[:,1]+1) # get rewards
 
     mean_time_step = int(np.mean(reward_list_total[:, 1])*100)/100. # get average time step
     max_time_step = int(np.max(reward_list_total[:, 1])*100)/100. # get average time step


### PR DESCRIPTION
The reward_list is currently the total reward over all runs, I think this is a bug as that reward is fed to the ES'tell() and it varies wildly depending on the number of runs made which shouldn't be a learning factor (this is especially visible when setting a constant negative reward for failure).