### PR TITLE
Fix methods name in custom_envs to be able to use the latest OpenAI Gym

### DIFF
--- a/custom_envs/minitaur_ball.py
+++ b/custom_envs/minitaur_ball.py
@@ -155,7 +155,7 @@ class MinitaurBallBulletEnv(gym.Env):
     else:
       self._pybullet_client = bullet_client.BulletClient()
 
-    self._seed()
+    self.seed()
     self.reset()
     observation_high = (
         self.minitaur.GetObservationUpperBound() + OBSERVATION_EPS)
@@ -174,7 +174,7 @@ class MinitaurBallBulletEnv(gym.Env):
   def configure(self, args):
     self._args = args
 
-  def _reset(self):
+  def reset(self):
     if self._hard_reset:
       self._pybullet_client.resetSimulation()
       self._pybullet_client.setPhysicsEngineParameter(
@@ -220,7 +220,7 @@ class MinitaurBallBulletEnv(gym.Env):
         self._pybullet_client.stepSimulation()
     return self._noisy_observation()
 
-  def _seed(self, seed=None):
+  def seed(self, seed=None):
     self.np_random, seed = seeding.np_random(seed)
     return [seed]
 
@@ -234,7 +234,7 @@ class MinitaurBallBulletEnv(gym.Env):
       action = self.minitaur.ConvertFromLegModel(action)
     return action
 
-  def _step(self, action):
+  def step(self, action):
     """Step forward the simulation, given the action.
     Args:
       action: A list of desired motor angles for eight motors.
@@ -268,7 +268,7 @@ class MinitaurBallBulletEnv(gym.Env):
     done = self._termination()
     return np.array(self._noisy_observation()), reward, done, {}
 
-  def _render(self, mode="rgb_array", close=False):
+  def render(self, mode="rgb_array", close=False):
     if mode != "rgb_array":
       return np.array([])
     base_pos = self.minitaur.GetBasePosition()

--- a/custom_envs/minitaur_ball.py
+++ b/custom_envs/minitaur_ball.py
@@ -155,7 +155,7 @@ class MinitaurBallBulletEnv(gym.Env):
     else:
       self._pybullet_client = bullet_client.BulletClient()
 
-    self.seed()
+    self._seed()
     self.reset()
     observation_high = (
         self.minitaur.GetObservationUpperBound() + OBSERVATION_EPS)
@@ -174,7 +174,7 @@ class MinitaurBallBulletEnv(gym.Env):
   def configure(self, args):
     self._args = args
 
-  def reset(self):
+  def _reset(self):
     if self._hard_reset:
       self._pybullet_client.resetSimulation()
       self._pybullet_client.setPhysicsEngineParameter(
@@ -220,7 +220,7 @@ class MinitaurBallBulletEnv(gym.Env):
         self._pybullet_client.stepSimulation()
     return self._noisy_observation()
 
-  def seed(self, seed=None):
+  def _seed(self, seed=None):
     self.np_random, seed = seeding.np_random(seed)
     return [seed]
 
@@ -234,7 +234,7 @@ class MinitaurBallBulletEnv(gym.Env):
       action = self.minitaur.ConvertFromLegModel(action)
     return action
 
-  def step(self, action):
+  def _step(self, action):
     """Step forward the simulation, given the action.
     Args:
       action: A list of desired motor angles for eight motors.
@@ -268,7 +268,7 @@ class MinitaurBallBulletEnv(gym.Env):
     done = self._termination()
     return np.array(self._noisy_observation()), reward, done, {}
 
-  def render(self, mode="rgb_array", close=False):
+  def _render(self, mode="rgb_array", close=False):
     if mode != "rgb_array":
       return np.array([])
     base_pos = self.minitaur.GetBasePosition()

--- a/custom_envs/minitaur_ball.py
+++ b/custom_envs/minitaur_ball.py
@@ -20,6 +20,7 @@ from pybullet_envs.bullet import bullet_client
 from pybullet_envs.bullet import minitaur
 import os
 import pybullet_data
+from pkg_resources import parse_version
 
 from pybullet_envs.bullet import minitaur_env_randomizer
 #from . import minitaur_env_randomizer
@@ -379,3 +380,9 @@ class MinitaurBallBulletEnv(gym.Env):
           scale=self._observation_noise_stdev, size=observation.shape) *
                       self.minitaur.GetObservationUpperBound())
     return observation
+
+  if parse_version(gym.__version__)>=parse_version('0.9.6'):
+    render = _render
+    reset = _reset
+    seed = _seed
+    step = _step

--- a/custom_envs/minitaur_duck.py
+++ b/custom_envs/minitaur_duck.py
@@ -155,7 +155,7 @@ class MinitaurDuckBulletEnv(gym.Env):
     else:
       self._pybullet_client = bullet_client.BulletClient()
 
-    self.seed()
+    self._seed()
     self.reset()
     observation_high = (
         self.minitaur.GetObservationUpperBound() + OBSERVATION_EPS)
@@ -174,7 +174,7 @@ class MinitaurDuckBulletEnv(gym.Env):
   def configure(self, args):
     self._args = args
 
-  def reset(self):
+  def _reset(self):
     if self._hard_reset:
       self._pybullet_client.resetSimulation()
       self._pybullet_client.setPhysicsEngineParameter(
@@ -217,7 +217,7 @@ class MinitaurDuckBulletEnv(gym.Env):
         self._pybullet_client.stepSimulation()
     return self._noisy_observation()
 
-  def seed(self, seed=None):
+  def _seed(self, seed=None):
     self.np_random, seed = seeding.np_random(seed)
     return [seed]
 
@@ -231,7 +231,7 @@ class MinitaurDuckBulletEnv(gym.Env):
       action = self.minitaur.ConvertFromLegModel(action)
     return action
 
-  def step(self, action):
+  def _step(self, action):
     """Step forward the simulation, given the action.
     Args:
       action: A list of desired motor angles for eight motors.
@@ -265,7 +265,7 @@ class MinitaurDuckBulletEnv(gym.Env):
     done = self._termination()
     return np.array(self._noisy_observation()), reward, done, {}
 
-  def render(self, mode="rgb_array", close=False):
+  def _render(self, mode="rgb_array", close=False):
     if mode != "rgb_array":
       return np.array([])
     base_pos = self.minitaur.GetBasePosition()

--- a/custom_envs/minitaur_duck.py
+++ b/custom_envs/minitaur_duck.py
@@ -155,7 +155,7 @@ class MinitaurDuckBulletEnv(gym.Env):
     else:
       self._pybullet_client = bullet_client.BulletClient()
 
-    self._seed()
+    self.seed()
     self.reset()
     observation_high = (
         self.minitaur.GetObservationUpperBound() + OBSERVATION_EPS)
@@ -174,7 +174,7 @@ class MinitaurDuckBulletEnv(gym.Env):
   def configure(self, args):
     self._args = args
 
-  def _reset(self):
+  def reset(self):
     if self._hard_reset:
       self._pybullet_client.resetSimulation()
       self._pybullet_client.setPhysicsEngineParameter(
@@ -217,7 +217,7 @@ class MinitaurDuckBulletEnv(gym.Env):
         self._pybullet_client.stepSimulation()
     return self._noisy_observation()
 
-  def _seed(self, seed=None):
+  def seed(self, seed=None):
     self.np_random, seed = seeding.np_random(seed)
     return [seed]
 
@@ -231,7 +231,7 @@ class MinitaurDuckBulletEnv(gym.Env):
       action = self.minitaur.ConvertFromLegModel(action)
     return action
 
-  def _step(self, action):
+  def step(self, action):
     """Step forward the simulation, given the action.
     Args:
       action: A list of desired motor angles for eight motors.
@@ -265,7 +265,7 @@ class MinitaurDuckBulletEnv(gym.Env):
     done = self._termination()
     return np.array(self._noisy_observation()), reward, done, {}
 
-  def _render(self, mode="rgb_array", close=False):
+  def render(self, mode="rgb_array", close=False):
     if mode != "rgb_array":
       return np.array([])
     base_pos = self.minitaur.GetBasePosition()

--- a/custom_envs/minitaur_duck.py
+++ b/custom_envs/minitaur_duck.py
@@ -20,6 +20,7 @@ from pybullet_envs.bullet import bullet_client
 from pybullet_envs.bullet import minitaur
 import os
 import pybullet_data
+from pkg_resources import parse_version
 
 from pybullet_envs.bullet import minitaur_env_randomizer
 #from . import minitaur_env_randomizer
@@ -376,3 +377,9 @@ class MinitaurDuckBulletEnv(gym.Env):
           scale=self._observation_noise_stdev, size=observation.shape) *
                       self.minitaur.GetObservationUpperBound())
     return observation
+
+  if parse_version(gym.__version__)>=parse_version('0.9.6'):
+    render = _render
+    reset = _reset
+    seed = _seed
+    step = _step


### PR DESCRIPTION
According to https://github.com/openai/gym/commit/4c460ba6c8959dd8e0a03b13a1ca817da6d4074f, `_step`, `_reset`, `_seed` and `_close` became non-underscored method.

This PR fixed it.